### PR TITLE
CI/CD and Download Compiled Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: "CI"
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: CI/CD Test
+    # https://github.com/actions/virtual-environments/
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v3
+
+      - name: 🔧 Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+
+      # Test
+      - name: 🌡️ Test
+        run: go run main.go -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🔧 Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,11 @@ jobs:
       - name: 🛎️ Checkout
         uses: actions/checkout@v3
 
+      # https://github.com/marketplace/actions/setup-go-environment
       - name: 🔧 Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
+          go-version: '>=1.20.0'
           go-version-file: 'go.mod'
 
       - name: 🍳 Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
       - name: 🔧 Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '>=1.20.0'
           go-version-file: 'go.mod'
 
       - name: 🍳 Build
@@ -99,7 +98,7 @@ jobs:
       # Release, upload files
       # https://github.com/marketplace/actions/gh-release
       - name: ✨ Release
-        uses: softprops/action-gh-release@v0.1.14
+        uses: softprops/action-gh-release@v1
         with:
           files: |
             go-andotp-linux-x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    name: Build
+    # https://github.com/actions/virtual-environments/
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v3
+
+      - name: 🔧 Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+
+      - name: 🍳 Build
+        run: bash build.sh
+
+      # Test binary
+      - name: 🌡️ Test
+        run: chmod +x go-andotp-linux-x86_64 && ./go-andotp-linux-x86_64 -h
+
+      # Upload binaries
+      # https://github.com/marketplace/actions/upload-a-build-artifact
+      - name: 📤 Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: go-andotp
+          path: go-andotp*
+          retention-days: 1
+
+  test-linux:
+    name: Test Linux
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v3
+      # Download binaries
+      # https://github.com/marketplace/actions/download-a-build-artifact
+      - name: 📥 Download
+        uses: actions/download-artifact@v3
+        with:
+          name: go-andotp
+      # Test binary
+      - name: 🌡️ Test
+        run: chmod +x go-andotp-linux-x86_64 && ./go-andotp-linux-x86_64 -h
+
+  test-macos:
+    name: Test macOS
+    needs: build
+    runs-on: macos-latest
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v3
+      - name: 📥 Download
+        uses: actions/download-artifact@v3
+        with:
+          name: go-andotp
+      # Test binary
+      - name: 🌡️ Test
+        run: chmod +x go-andotp-macos-x86_64 && ./go-andotp-macos-x86_64 -h
+
+  test-windows:
+    name: Test Windows
+    needs: build
+    runs-on: windows-latest
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v3
+      - name: 📥 Download
+        uses: actions/download-artifact@v3
+        with:
+          name: go-andotp
+      # Test binary
+      - name: 🌡️ Test
+        run: .\go-andotp-windows-x86_64.exe -h
+
+  release:
+    name: Release
+    needs: [test-linux, test-macos, test-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v3
+      - name: 📥 Download
+        uses: actions/download-artifact@v3
+        with:
+          name: go-andotp
+      # Release, upload files
+      # https://github.com/marketplace/actions/gh-release
+      - name: ✨ Release
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          files: |
+            go-andotp-linux-x86_64
+            go-andotp-linux-arm64
+            go-andotp-macos-x86_64
+            go-andotp-macos-arm64
+            go-andotp-windows-x86_64.exe
+            go-andotp-windows-arm64.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+go-andotp*
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work

--- a/README.md
+++ b/README.md
@@ -112,5 +112,25 @@ func main() {
 }
 ```
 
+## Build
+Compile `go-andotp` on your computer:
+
+```shell
+go build -o go-andotp main.go
+```
+
+To compile `go-andotp` for another platform please set the `GOARCH` and `GOOS` environmental variables.
+Example:
+```shell
+GOOS=windows GOARCH=amd64 go build -o go-andotp.exe main.go
+```
+
+To compile `go-andotp` for Windows, macOS and Linux you can use the script `build.sh`:
+```shell
+bash build.sh
+```
+
+More help: <https://go.dev/doc/install/source#environment>
+
 # License
 [MIT](https://github.com/grijul/go-andotp/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,72 @@
 CLI program to encrypt/decrypt [andOTP](https://github.com/andOTP/andOTP) files.
 
 ## Installation
-```sh
-$ go get github.com/grijul/go-andotp
+
+<details>
+<summary><b>Linux</b></summary>
+
+Download:
+* [x86_64](https://github.com/RijulGulati/go-andotp/releases/latest/download/go-andotp-linux-x86_64) Intel or AMD 64-Bit CPU
+  ```shell
+  curl -L "https://github.com/RijulGulati/go-andotp/releases/latest/download/go-andotp-linux-x86_64" \
+       -o "go-andotp" && \
+  chmod +x "go-andotp"
+  ```
+* [arm64](https://github.com/RijulGulati/go-andotp/releases/latest/download/go-andotp-linux-arm64) Arm-based 64-Bit CPU (i.e. in Raspberry Pi)
+  ```shell
+  curl -L "https://github.com/RijulGulati/go-andotp/releases/latest/download/go-andotp-linux-arm64" \
+       -o "go-andotp" && \
+  chmod +x "go-andotp"
+  ```
+
+To determine your OS version, run `getconf LONG_BIT` or `uname -m` at the command line.
+</details>
+
+<details>
+<summary><b>macOS</b></summary>
+
+Download:
+* [x86_64](https://github.com/RijulGulati/go-andotp/releases/latest/download/go-andotp-macos-x86_64) Intel 64-bit
+  ```shell
+  curl -L "https://github.com/RijulGulati/go-andotp/releases/latest/download/go-andotp-macos-x86_64" \
+       -o "go-andotp" && \
+  chmod +x "go-andotp"
+  ```
+* [arm64](https://github.com/RijulGulati/go-andotp/releases/latest/download/go-andotp-macos-arm64) Apple silicon 64-bit
+  ```shell
+  curl -L "https://github.com/RijulGulati/go-andotp/releases/latest/download/go-andotp-macos-arm64" \
+       -o "go-andotp" && \
+  chmod +x "go-andotp"
+  ```
+
+To determine your OS version, run `uname -m` at the command line.
+</details>
+
+<details>
+<summary><b>Windows</b></summary>
+
+Download:
+* [x86_64](https://github.com/RijulGulati/go-andotp/releases/latest/download/go-andotp-windows-x86_64.exe) Intel or AMD 64-Bit CPU
+   ```powershell
+   Invoke-WebRequest -Uri "https://github.com/RijulGulati/go-andotp/releases/latest/download/go-andotp-windows-x86_64.exe" -OutFile "go-andotp.exe"
+   ```
+* [arm64](https://github.com/RijulGulati/go-andotp/releases/latest/download/go-andotp-windows-arm64.exe) Arm-based 64-Bit CPU
+   ```powershell
+   Invoke-WebRequest -Uri "https://github.com/RijulGulati/go-andotp/releases/latest/download/go-andotp-windows-arm64.exe" -OutFile "go-andotp.exe"
+   ```
+To determine your OS version, run `echo %PROCESSOR_ARCHITECTURE%` at the command line.
+</details>
+
+<details>
+<summary><b>Go</b></summary>
+
+```shell
+go install github.com/grijul/go-andotp
 ```
+</details>
 
 ## Usage
-```sh
+```text
 Usage: go-andotp -i <INPUT_FILE> {-e|-d} [-o <OUT_FILE>] [-p PASSWORD]
 
   -d    Decrypt file
@@ -22,20 +82,20 @@ Usage: go-andotp -i <INPUT_FILE> {-e|-d} [-o <OUT_FILE>] [-p PASSWORD]
 
 ## Examples
 - Encrypt JSON file (Password is asked after hitting ```Enter```. Password is not echoed)
-```sh
-$ go-andotp -e -i file.json -o file.json.aes
+```shell
+go-andotp -e -i file.json -o file.json.aes
 ```
 - Encrypt JSON file (Password is entered through CLI)
-```sh
-$ go-andotp -e -i file.json -o file.json.aes -p testpass
+```shell
+go-andotp -e -i file.json -o file.json.aes -p testpass
 ```
 - Decrypt JSON file
-```sh
-$ go-andotp -d -i file.aes.json -o file.json
+```shell
+go-andotp -d -i file.aes.json -o file.json
 ```
 - Decrypt JSON file and print json to console
-```sh
-$ go-andotp -d -i file.aes.json
+```shell
+go-andotp -d -i file.aes.json
 ```
 
 ## Using go-andotp as library

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+go version || exit 9
+
 # Linux
 echo "Linux"                                                       && \
 GOOS=linux GOARCH=amd64 go build -o go-andotp-linux-x86_64 main.go && \

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Linux
+echo "Linux"                                                       && \
+GOOS=linux GOARCH=amd64 go build -o go-andotp-linux-x86_64 main.go && \
+GOOS=linux GOARCH=arm64 go build -o go-andotp-linux-arm64  main.go && \
+
+# macOS
+echo "macOS"                                                        && \
+GOOS=darwin GOARCH=amd64 go build -o go-andotp-macos-x86_64 main.go && \
+GOOS=darwin GOARCH=arm64 go build -o go-andotp-macos-arm64  main.go && \
+
+# Windows
+echo "Windows"                                                             && \
+GOOS=windows GOARCH=amd64 go build -o go-andotp-windows-x86_64.exe main.go && \
+GOOS=windows GOARCH=arm64 go build -o go-andotp-windows-arm64.exe  main.go && \
+
+echo "✅ DONE"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grijul/go-andotp
 
-go 1.16
+go 1.20
 
 require (
 	golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf


### PR DESCRIPTION
Hi,

I created some GitHub Actions to test and compile the Go program. A user can then download the compiled and ready to use version. No golang needed.

You must adjust the [Workflow permissions](https://github.com/RijulGulati/go-andotp/settings/actions) and allow read and write:

![image](https://user-images.githubusercontent.com/176242/227923013-444bf56c-5ec5-4c0a-998d-219edac22a8d.png)

Then you can create a release with the tag format `v*.*.*`.

GitHub Action will compile and upload the compiled binaries to the release.

Example: https://github.com/Cyclenerd/go-andotp/releases

I also changed the min. go version to `1.20` for Windows and ARM support.

The README.md is optimized for copy and paste.

Best regards
Nils